### PR TITLE
spawnctl: scan: change UI

### DIFF
--- a/spawnclient/client.go
+++ b/spawnclient/client.go
@@ -19,10 +19,12 @@ type SpawnClient struct {
 }
 
 func New(router string, entityFile string) (*SpawnClient, error) {
+	bw2.SilenceLog()
 	BWC, err := bw2.Connect(router)
 	if err != nil {
 		return nil, err
 	}
+	BWC.StatLine()
 
 	_, err = BWC.SetEntityFile(entityFile)
 	if err != nil {


### PR DESCRIPTION
This basically focuses on the scan command
- If the user forgets --uri just be kind, there is only one parameter
- Change indenting, time formatting and bw2bind logs so that it goes from 

```
1473877028525581410 [Info] Connected to BOSSWAVE router version 2.4.11 'Hadron'
Discovered 1 SpawnPoint(s):
[spawnpoint] seen 14 Sep 16 11:17 PDT (1.137603329s) ago at nvrnSE4pJe4ZMO3WQdb-EPi5iwuzmTVUpk6XNNRGYsc=/sasc/spawnpoint
    Available Memory: 1792 MB, Available Cpu Shares: 1792
• [mpa_reference] seen 14 Sep 16 11:17 PDT (339.239989ms) ago
    Memory: 256 MB, Cpu Shares: 256
Metadata:
  • location: cloud
  • arch: amd64
  • lastalive: 2016-09-14 18:17:07.962410503 +0000 UTC
```

to

```
 ╔╡localhost:28589 2.4.11 'Hadron'
 ╚╡peers=17 block=1044615 age=12s
Discovered 1 SpawnPoint(s):
[spawnpoint] seen 14 Sep 16 11:20 PDT (2.01s) ago at nvrnSE4pJe4ZMO3WQdb-EPi5iwuzmTVUpk6XNNRGYsc=/sasc/spawnpoint
  Available Memory: 1792 MB, Available Cpu Shares: 1792
  • [mpa_reference] seen 14 Sep 16 11:20 PDT (2.46s) ago
      Memory: 256 MB, Cpu Shares: 256
      Metadata:
        • location: cloud
        • arch: amd64
        • lastalive: 2016-09-14 18:20:28.057866073 +0000 UTC
```
