### PR TITLE
Allow command line agent config for bw2mon

### DIFF
--- a/bw2mon/bw2Mon.go
+++ b/bw2mon/bw2Mon.go
@@ -23,6 +23,10 @@ func main() {
 			EnvVar: "BW2_DEFAULT_ENTITY",
 		},
 		cli.StringFlag{
+			Name:   "agent",
+			EnvVar: "BW2_AGENT",
+		},
+		cli.StringFlag{
 			Name: "prefix",
 		},
 		cli.StringSliceFlag{
@@ -70,7 +74,7 @@ func runApp(c *cli.Context) error {
 		wdNames[i] = prefix + tokens[1]
 	}
 
-	bwClient := bw2.ConnectOrExit("")
+	bwClient := bw2.ConnectOrExit(c.String("agent"))
 	bwClient.SetEntityFileOrExit(c.String("entity"))
 
 	var wg sync.WaitGroup


### PR DESCRIPTION
Yes, you can do it with the environment variable, but while we're doing it for `BW2_DEFAULT_ENTITY`, why not `BW2_AGENT` as well? 